### PR TITLE
Add global context for better state management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,4 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import Sidebar from './components/Sidebar'
 import './App.css'
 import Home from './pages/Home'
@@ -9,29 +7,14 @@ import Trade from './pages/Trade'
 import TradingAction from './components/TradingAction'
 
 function App() {
-    const [tradingActionModalOpen, setTradingActionModalOpen] = useState(false)
-    const [selectedSymbol, setSelectedSymbol] = useState('')
     return (
         <div className="flex">
             <Sidebar />
             <Routes>
-                <Route
-                    path="/"
-                    element={
-                        <Home
-                            handleTradingAction={setTradingActionModalOpen}
-                            handleSymbolSelect={setSelectedSymbol}
-                        />
-                    }
-                />
+                <Route path="/" element={<Home />} />
                 <Route path="/trade" element={<Trade />} />
             </Routes>
-            <TradingAction
-                tradingActionModalOpen={tradingActionModalOpen}
-                setTradingActionModalOpen={setTradingActionModalOpen}
-                selectedSymbol={selectedSymbol}
-                setSelectedSymbol={setSelectedSymbol}
-            />
+            <TradingAction />
         </div>
     )
 }

--- a/frontend/src/GlobalContext.tsx
+++ b/frontend/src/GlobalContext.tsx
@@ -1,0 +1,67 @@
+import { createContext, useReducer, useContext } from 'react'
+
+interface TradingModalState {
+    isOpen: boolean
+    symbol?: string
+}
+interface TradingModalContextType {
+    tradingModalState: TradingModalState
+    tradingModalDispatch: React.Dispatch<{
+        type: string
+        state?: TradingModalState
+    }>
+}
+
+const initTradingModalContext: TradingModalContextType = {
+    tradingModalState: {
+        isOpen: false,
+        symbol: '',
+    },
+    tradingModalDispatch: () => {},
+}
+
+const GlobalContext = createContext<TradingModalContextType>(
+    initTradingModalContext
+)
+
+export function GlobalProvider({ children }: any) {
+    const [tradingModalState, tradingModalDispatch] = useReducer(
+        tradingModalReducer,
+        initTradingModalState
+    )
+
+    return (
+        <GlobalContext.Provider
+            value={{ tradingModalState, tradingModalDispatch }}
+        >
+            {children}
+        </GlobalContext.Provider>
+    )
+}
+
+function tradingModalReducer(
+    state: TradingModalState,
+    action: { type: string; state?: TradingModalState }
+) {
+    switch (action.type) {
+        case 'OPEN_MODAL':
+            return { ...state, isOpen: true }
+        case 'CLOSE_MODAL':
+            return { ...state, isOpen: false }
+        case 'UPDATE_MODAL_SYMBOL':
+            return { ...state, symbol: action.state?.symbol }
+        case 'OPEN_MODAL_WITH_DATA':
+            return { ...state, isOpen: true, symbol: action.state?.symbol }
+        default:
+            throw new Error(`Unknown action type: ${action.type}`)
+    }
+}
+
+const initTradingModalState: TradingModalState = {
+    isOpen: false,
+    symbol: '',
+}
+
+export function useGlobalContext() {
+    return useContext(GlobalContext)
+}

--- a/frontend/src/GlobalContext.tsx
+++ b/frontend/src/GlobalContext.tsx
@@ -24,7 +24,7 @@ const GlobalContext = createContext<TradingModalContextType>(
     initTradingModalContext
 )
 
-export function GlobalProvider({ children }: any) {
+export function GlobalProvider({ children }: { children: React.ReactNode }) {
     const [tradingModalState, tradingModalDispatch] = useReducer(
         tradingModalReducer,
         initTradingModalState

--- a/frontend/src/components/TradingAction.tsx
+++ b/frontend/src/components/TradingAction.tsx
@@ -13,11 +13,7 @@ import {
 } from '@mui/material'
 import { useGlobalContext } from '../GlobalContext'
 
-interface TradingActionProps {
-    selectedSymbol?: string
-}
-function TradingAction(props: TradingActionProps) {
-    const { selectedSymbol } = props
+function TradingAction() {
     const { tradingModalState, tradingModalDispatch } = useGlobalContext()
 
     const handleOpen = () => {
@@ -96,11 +92,7 @@ function TradingAction(props: TradingActionProps) {
                                     },
                                 })
                             }
-                            value={
-                                selectedSymbol
-                                    ? selectedSymbol
-                                    : tradingModalState.symbol
-                            }
+                            value={tradingModalState.symbol}
                         ></TextField>
                         <TextField
                             required

--- a/frontend/src/components/TradingAction.tsx
+++ b/frontend/src/components/TradingAction.tsx
@@ -11,35 +11,34 @@ import {
     Typography,
     type SelectChangeEvent,
 } from '@mui/material'
+import { useGlobalContext } from '../GlobalContext'
 
 interface TradingActionProps {
-    tradingActionModalOpen: boolean
-    setTradingActionModalOpen: (open: boolean) => void
     selectedSymbol?: string
-    setSelectedSymbol: (symbol: string) => void
 }
 function TradingAction(props: TradingActionProps) {
-    const {
-        tradingActionModalOpen,
-        setTradingActionModalOpen,
-        selectedSymbol,
-        setSelectedSymbol,
-    } = props
+    const { selectedSymbol } = props
+    const { tradingModalState, tradingModalDispatch } = useGlobalContext()
+
     const handleOpen = () => {
-        setSelectedSymbol('')
-        setTradingActionModalOpen(true)
+        tradingModalDispatch({
+            type: 'OPEN_MODAL_WITH_DATA',
+            state: { isOpen: true, symbol: '' },
+        })
     }
     const handleClose = () => {
-        setTradingActionModalOpen(false)
+        tradingModalDispatch({
+            type: 'CLOSE_MODAL',
+        })
     }
     const [action, setAction] = useState('')
 
     const handleChange = (event: SelectChangeEvent) => {
         setAction(event.target.value as string)
     }
-    const [symbol, setSymbol] = useState('')
     const [quantity, setQuantity] = useState('')
     const [currentPrice, setCurrentPrice] = useState(10)
+
     return (
         <div>
             <Button
@@ -59,7 +58,7 @@ function TradingAction(props: TradingActionProps) {
             >
                 Buy / Sell
             </Button>
-            <Modal open={tradingActionModalOpen} onClose={handleClose}>
+            <Modal open={tradingModalState.isOpen} onClose={handleClose}>
                 <Box
                     sx={{
                         width: 400,
@@ -88,8 +87,20 @@ function TradingAction(props: TradingActionProps) {
                             required
                             label="Stock Symbol"
                             placeholder="ex: AAPL"
-                            onChange={(e) => setSymbol(e.target.value)}
-                            value={selectedSymbol ? selectedSymbol : symbol}
+                            onChange={(e) =>
+                                tradingModalDispatch({
+                                    type: 'UPDATE_MODAL_SYMBOL',
+                                    state: {
+                                        isOpen: true,
+                                        symbol: e.target.value,
+                                    },
+                                })
+                            }
+                            value={
+                                selectedSymbol
+                                    ? selectedSymbol
+                                    : tradingModalState.symbol
+                            }
                         ></TextField>
                         <TextField
                             required

--- a/frontend/src/components/UserStocksTable.tsx
+++ b/frontend/src/components/UserStocksTable.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useState, useEffect } from 'react'
 import { alpha } from '@mui/material/styles'
+import { useGlobalContext } from '../GlobalContext'
 import {
     Box,
     Table,
@@ -123,15 +124,6 @@ function EnhancedTableHead(props: EnhancedTableProps) {
     return (
         <TableHead>
             <TableRow>
-                {/* <TableCell padding="checkbox">
-                    <Checkbox
-                        color="primary"
-                        indeterminate={
-                            numSelected > 0 && numSelected < rowCount
-                        }
-                        checked={rowCount > 0 && numSelected === rowCount}
-                    />
-                </TableCell> */}
                 <TableCell padding="checkbox"></TableCell>
                 {headCells.map((headCell) => (
                     <TableCell
@@ -224,12 +216,8 @@ function EnhancedTableToolbar(props: EnhancedTableToolbarProps) {
         </Toolbar>
     )
 }
-interface UserStocksTableProps {
-    handleTradingAction: (open: boolean) => void
-    handleSymbolSelect: (symbol: string) => void
-}
-export default function UserStocksTable(props: UserStocksTableProps) {
-    const { handleTradingAction, handleSymbolSelect } = props
+
+export default function UserStocksTable() {
     const [order, setOrder] = React.useState<Order>('asc')
     const [orderBy, setOrderBy] = React.useState<keyof StockData>('ticker')
     const [selectedId, setSelectedId] = useState(-1)
@@ -238,9 +226,12 @@ export default function UserStocksTable(props: UserStocksTableProps) {
     const [rowsPerPage, setRowsPerPage] = React.useState(5)
     const [selectedSymbol, setSelectedSymbol] = useState('')
 
+    const { tradingModalState, tradingModalDispatch } = useGlobalContext()
     const handleUserOpen = () => {
-        handleSymbolSelect(selectedSymbol)
-        handleTradingAction(true)
+        tradingModalDispatch({
+            type: 'OPEN_MODAL_WITH_DATA',
+            state: { isOpen: true, symbol: selectedSymbol },
+        })
     }
 
     const handleRequestSort = (

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import { GlobalProvider } from './GlobalContext.js'
 import App from './App.tsx'
 import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <GlobalProvider>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </GlobalProvider>
     </StrictMode>
 )

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,17 +1,10 @@
 import React from 'react'
 import UserStocksTable from '../components/UserStocksTable'
-interface HomeProps {
-    handleTradingAction: (open: boolean) => void
-    handleSymbolSelect: (symbol: string) => void
-}
-function Home(props: HomeProps) {
-    const { handleTradingAction, handleSymbolSelect } = props
+
+function Home() {
     return (
         <div style={{ display: 'flex', marginLeft: 240 }}>
-            <UserStocksTable
-                handleTradingAction={handleTradingAction}
-                handleSymbolSelect={handleSymbolSelect}
-            />
+            <UserStocksTable />
         </div>
     )
 }


### PR DESCRIPTION
added a global context to wrap the react app, to better manage react states. 
React states can now be passed globally through this context instead of being passed explicitly through the component tree. 
I also cleaned up some code 